### PR TITLE
Fix pbr package name

### DIFF
--- a/osc_choochoo/__init__.py
+++ b/osc_choochoo/__init__.py
@@ -16,4 +16,4 @@ import pbr.version
 
 
 __version__ = pbr.version.VersionInfo(
-    'osc_loco').version_string()
+    'osc_choochoo').version_string()


### PR DESCRIPTION
The package name given to pbr did not match the package name in
setup.cfg and caused a pbr error on import when osc was run from outside
of the program directory. This patch ensures the package name given to
pbr matches what's in setuptools.